### PR TITLE
Feature/add config attribute

### DIFF
--- a/examples/http.php
+++ b/examples/http.php
@@ -5,9 +5,19 @@ declare(strict_types=1);
 require __DIR__ . '/../vendor/autoload.php';
 
 use GuzzleHttp\Psr7\Response as Psr7Response;
+use Kekke\Mononoke\Attributes\Config;
 use Kekke\Mononoke\Attributes\Http;
+use Kekke\Mononoke\Models\AwsConfig;
+use Kekke\Mononoke\Models\HttpConfig;
+use Kekke\Mononoke\Models\MononokeConfig;
 use Kekke\Mononoke\Service as MononokeService;
 
+
+#[Config(
+    mononokeConfig: new MononokeConfig(numberOfTaskWorkers: 5),
+    awsConfig: new AwsConfig(sqsPollTimeInSeconds: 10),
+    httpConfig: new HttpConfig(port: 8080),
+)]
 class Service extends MononokeService
 {
     #[Http('GET', '/health')]

--- a/src/Attributes/Config.php
+++ b/src/Attributes/Config.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kekke\Mononoke\Attributes;
+
+use Attribute;
+use Kekke\Mononoke\Models\AwsConfig;
+use Kekke\Mononoke\Models\HttpConfig;
+use Kekke\Mononoke\Models\MononokeConfig;
+
+/**
+ * Attribute to define config options.
+ */
+#[Attribute(Attribute::TARGET_CLASS)]
+class Config
+{
+    public function __construct(
+        public MononokeConfig $mononokeConfig = new MononokeConfig(),
+        public AwsConfig $awsConfig = new AwsConfig(),
+        public HttpConfig $httpConfig = new HttpConfig(),
+    ) {}
+}

--- a/src/Config/ConfigLoader.php
+++ b/src/Config/ConfigLoader.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kekke\Mononoke\Config;
+
+use Kekke\Mononoke\Attributes\Config;
+use Kekke\Mononoke\Reflection\AttributeScanner;
+
+class ConfigLoader
+{
+    public function load(object $service): Config
+    {
+        $scanner = new AttributeScanner($service);
+        return $scanner->getAttributeInstanceFromClass(Config::class);
+    }
+}

--- a/src/Framework.php
+++ b/src/Framework.php
@@ -27,6 +27,7 @@ class Framework
             if (is_subclass_of($class, Service::class)) {
                 $service = new $class();
                 self::displayInfo();
+                $service->loadConfig();
                 $service->run();
                 return;
             }

--- a/src/Models/AwsConfig.php
+++ b/src/Models/AwsConfig.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kekke\Mononoke\Models;
+
+class AwsConfig
+{
+    public function __construct(public int $sqsPollTimeInSeconds = 5) {}
+}

--- a/src/Models/HttpConfig.php
+++ b/src/Models/HttpConfig.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kekke\Mononoke\Models;
+
+class HttpConfig
+{
+    public function __construct(public int $port = 80) {}
+}

--- a/src/Models/MononokeConfig.php
+++ b/src/Models/MononokeConfig.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kekke\Mononoke\Models;
+
+class MononokeConfig
+{
+    public function __construct(public string $serviceName = 'default', public int $numberOfTaskWorkers = 2) {}
+}

--- a/src/Reflection/AttributeScanner.php
+++ b/src/Reflection/AttributeScanner.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Kekke\Mononoke\Reflection;
 
+use Kekke\Mononoke\Attributes\Config;
 use ReflectionClass;
 use ReflectionMethod;
 
@@ -19,6 +20,24 @@ class AttributeScanner
     public function __construct(private readonly object $target)
     {
         $this->cacheAttributes();
+    }
+
+    public function getAttributeInstanceFromClass(string $attributeClass): Config
+    {
+        $reflector = new ReflectionClass($this->target);
+
+        $attributes = $reflector->getAttributes($attributeClass);
+        if (empty($attributes)) {
+            return new Config();
+        }
+
+        $config = $attributes[0]->newInstance();
+
+        if ($config instanceof Config) {
+            return $config;
+        }
+
+        return new Config();
     }
 
     /**

--- a/tests/Config/ConfigTest.php
+++ b/tests/Config/ConfigTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+use Kekke\Mononoke\Attributes\Config;
+use Kekke\Mononoke\Models\AwsConfig;
+use Kekke\Mononoke\Models\HttpConfig;
+use Kekke\Mononoke\Models\MononokeConfig;
+use Kekke\Mononoke\Service as MononokeService;
+use PHPUnit\Framework\TestCase;
+
+#[Config(
+    mononokeConfig: new MononokeConfig(numberOfTaskWorkers: 5),
+    awsConfig: new AwsConfig(sqsPollTimeInSeconds: 10),
+    httpConfig: new HttpConfig(port: 8080),
+)]
+class TestService extends MononokeService {}
+
+final class ConfigTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        putenv('HTTP_PORT');
+        putenv('TASK_WORKERS');
+        putenv('SQS_POLL_TIME');
+    }
+
+    public function testDefaultConfigFromAttributes(): void
+    {
+        $service = new TestService();
+        $service->loadConfig();
+        $config = $service->getConfig();
+
+        $this->assertSame(5, $config->mononokeConfig->numberOfTaskWorkers);
+        $this->assertSame(10, $config->awsConfig->sqsPollTimeInSeconds);
+        $this->assertSame(8080, $config->httpConfig->port);
+    }
+
+    public function testHttpPortOverrideFromEnv(): void
+    {
+        putenv('HTTP_PORT=9090');
+
+        $service = new TestService();
+        $service->loadConfig();
+        $config = $service->getConfig();
+
+        $this->assertSame(9090, $config->httpConfig->port);
+    }
+
+    public function testMultipleOverrides(): void
+    {
+        putenv('HTTP_PORT=9090');
+        putenv('TASK_WORKERS=12');
+        putenv('SQS_POLL_TIME=30');
+
+        $service = new TestService();
+        $service->loadConfig();
+        $config = $service->getConfig();
+
+        $this->assertSame(12, $config->mononokeConfig->numberOfTaskWorkers);
+        $this->assertSame(30, $config->awsConfig->sqsPollTimeInSeconds);
+        $this->assertSame(9090, $config->httpConfig->port);
+    }
+}


### PR DESCRIPTION
This PR adds a config attribute to Mononoke.

The reason for having config as an attribute is to make DX (developer experience) as smooth as possible, by using attributes with config classes we are declarative and discoverable.

The config also allows you to override values with ENV variables, these might be a bit hidden as of now, but it is currently possible to override the following 3 options:

        putenv('HTTP_PORT');
        putenv('TASK_WORKERS');
        putenv('SQS_POLL_TIME');

An example of using the Config attribute:

```php
#[Config(
    mononokeConfig: new MononokeConfig(numberOfTaskWorkers: 5),
    awsConfig: new AwsConfig(sqsPollTimeInSeconds: 10),
    httpConfig: new HttpConfig(port: 8080),
)]
class Service extends MononokeService
```