### PR TITLE
Feature: Dead Letter Queue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,14 @@
             "Kekke\\Mononoke\\": "src/"
         }
     },
-    "bin": ["src/bin/mononoke"],
+    "autoload-dev": {
+        "psr-4": {
+            "Kekke\\PHPStan\\": "phpstan/"
+        }
+    },
+    "bin": [
+        "src/bin/mononoke"
+    ],
     "authors": [
         {
             "name": "Henric Johansson",

--- a/composer.lock
+++ b/composer.lock
@@ -1347,16 +1347,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.22",
+            "version": "2.1.29",
             "source": {
                 "type": "git",
-                "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "41600c8379eb5aee63e9413fe9e97273e25d57e4"
+                "url": "https://github.com/phpstan/phpstan-phar-composer-source.git",
+                "reference": "git"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/41600c8379eb5aee63e9413fe9e97273e25d57e4",
-                "reference": "41600c8379eb5aee63e9413fe9e97273e25d57e4",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/d618573eed4a1b6b75e37b2e0b65ac65c885d88e",
+                "reference": "d618573eed4a1b6b75e37b2e0b65ac65c885d88e",
                 "shasum": ""
             },
             "require": {
@@ -1401,7 +1401,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-08-04T19:17:37+00:00"
+            "time": "2025-09-25T06:58:18+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/examples/sns.php
+++ b/examples/sns.php
@@ -29,6 +29,12 @@ class Service extends MononokeService
         Logger::info("Received message in another-topic!", ["Message" => $message]);
     }
 
+    #[AwsSnsSqs(topicName: 'sns-topic', queueName: 'sqs-queue', dlqName: 'sqs-queue-dlq')]
+    public function queueWithDlq($message)
+    {
+        throw new Exception("Error occurred, send to dlq after 3 tries");
+    }
+
     #[Http(HttpMethod::GET, '/health')]
     public function status()
     {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,2 +1,11 @@
 parameters:
-	reportUnmatchedIgnoredErrors: false
+    reportUnmatchedIgnoredErrors: false
+    paths:
+        - src
+        - tests
+        - phpstan/Rules
+
+services:
+    -
+        class: Kekke\PHPStan\Rules\ImmutableConfigConstructorRule
+        tags: [phpstan.rules.rule]

--- a/phpstan/Rules/ImmutableConfigConstructorRule.php
+++ b/phpstan/Rules/ImmutableConfigConstructorRule.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kekke\PHPStan\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @implements Rule<ClassMethod>
+ */
+class ImmutableConfigConstructorRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return ClassMethod::class;
+    }
+
+    /**
+     * @param ClassMethod $node
+     * @return list<string>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if ($node->name->toString() !== '__construct') {
+            return [];
+        }
+
+        $classReflection = $scope->getClassReflection();
+        if (!$classReflection instanceof ClassReflection) {
+            return [];
+        }
+
+        if (!$classReflection->isSubclassOf(\Kekke\Mononoke\Models\ImmutableConfig::class)) {
+            return [];
+        }
+
+        $hasParentCall = false;
+        foreach ($node->getStmts() ?? [] as $stmt) {
+            if (
+                $stmt instanceof Node\Stmt\Expression &&
+                $stmt->expr instanceof Node\Expr\StaticCall &&
+                $stmt->expr->class instanceof Node\Name &&
+                $stmt->expr->class->toString() === 'parent' &&
+                $stmt->expr->name->toString() === '__construct'
+            ) {
+                $hasParentCall = true;
+                break;
+            }
+        }
+
+        if (!$hasParentCall) {
+            return [
+                RuleErrorBuilder::message(sprintf(
+                    'Class %s extends ImmutableConfig but its constructor does not call parent::__construct().',
+                    $classReflection->getName()
+                ))->build()
+            ];
+        }
+
+        return [];
+    }
+}

--- a/src/Attributes/AwsSnsSqs.php
+++ b/src/Attributes/AwsSnsSqs.php
@@ -18,7 +18,7 @@ use Kekke\Mononoke\Exceptions\InvalidAttributeConfigurationException;
 #[Attribute(Attribute::TARGET_METHOD)]
 class AwsSnsSqs
 {
-    public function __construct(public string $topicName, public string $queueName)
+    public function __construct(public string $topicName, public string $queueName, public ?string $dlqName = null)
     {
         $this->validate();
     }
@@ -30,6 +30,10 @@ class AwsSnsSqs
         }
 
         if (! preg_match("/^[A-Za-z0-9-_]+/", $this->queueName)) {
+            throw new InvalidAttributeConfigurationException("Queue Name may only include alphanumeric characters, dashes and hyphens (given: \"$this->queueName\"");
+        }
+
+        if ($this->dlqName && ! preg_match("/^[A-Za-z0-9-_]+/", $this->dlqName)) {
             throw new InvalidAttributeConfigurationException("Queue Name may only include alphanumeric characters, dashes and hyphens (given: \"$this->queueName\"");
         }
     }

--- a/src/Aws/SnsSqsInstaller.php
+++ b/src/Aws/SnsSqsInstaller.php
@@ -6,6 +6,7 @@ namespace Kekke\Mononoke\Aws;
 
 use Aws\Exception\AwsException;
 use Kekke\Mononoke\Exceptions\MononokeException;
+use Kekke\Mononoke\Models\AwsConfig;
 use Kekke\Mononoke\Services\SnsService;
 use Kekke\Mononoke\Services\SqsService;
 
@@ -19,7 +20,7 @@ class SnsSqsInstaller
     /**
      * Sets up a SNS topic and a SQS queue
      */
-    public function setup(SnsService $snsService = new SnsService(), SqsService $sqsService = new SqsService()): void
+    public function setup(AwsConfig $config = new AwsConfig(), SnsService $snsService = new SnsService(), SqsService $sqsService = new SqsService()): void
     {
         try {
             $topicArn = $snsService->create(topicName: $this->topicName);
@@ -54,7 +55,7 @@ class SnsSqsInstaller
 
                 $redrivePolicy = json_encode([
                     'deadLetterTargetArn' => $dlqAttributes['Attributes']['QueueArn'],
-                    'maxReceiveCount'     => 5,
+                    'maxReceiveCount'     => $config->dlqMaxRetryCount,
                 ]);
 
                 $sqsService->setAttributes(

--- a/src/Config/OverrideApplier.php
+++ b/src/Config/OverrideApplier.php
@@ -35,7 +35,7 @@ class OverrideApplier
         $type = gettype($configPart->{$override->varName});
         $casted = $this->castToType($envValue, $type);
 
-        $config->{$override->configName}->{$override->varName} = $casted;
+        $config->{$override->configName} = $config->{$override->configName}->with($override->varName, $casted);
     }
 
     private function castToType(mixed $value, string $type): mixed

--- a/src/Config/Overrides.php
+++ b/src/Config/Overrides.php
@@ -20,6 +20,7 @@ class Overrides implements \IteratorAggregate
             new Override(configName: 'mononoke', varName: 'numberOfTaskWorkers', envVar: 'TASK_WORKERS'),
             new Override(configName: 'http', varName: 'port', envVar: 'HTTP_PORT'),
             new Override(configName: 'aws', varName: 'sqsPollTimeInSeconds', envVar: 'SQS_POLL_TIME'),
+            new Override(configName: 'aws', varName: 'dlqMaxRetryCount', envVar: 'SQS_DLQ_MAX_RETRIES')
         ];
     }
 

--- a/src/Exceptions/ImmutableConfigIsNotImmutableException.php
+++ b/src/Exceptions/ImmutableConfigIsNotImmutableException.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kekke\Mononoke\Exceptions;
+
+final class ImmutableConfigIsNotImmutableException extends MononokeException {}

--- a/src/Models/AwsConfig.php
+++ b/src/Models/AwsConfig.php
@@ -9,5 +9,7 @@ final class AwsConfig extends ImmutableConfig
     public function __construct(
         public readonly int $sqsPollTimeInSeconds = 5,
         public readonly int $dlqMaxRetryCount = 3
-    ) {}
+    ) {
+        parent::__construct();
+    }
 }

--- a/src/Models/AwsConfig.php
+++ b/src/Models/AwsConfig.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Kekke\Mononoke\Models;
 
-final class AwsConfig
+final class AwsConfig extends ImmutableConfig
 {
     public function __construct(
         public readonly int $sqsPollTimeInSeconds = 5,

--- a/src/Models/AwsConfig.php
+++ b/src/Models/AwsConfig.php
@@ -6,5 +6,5 @@ namespace Kekke\Mononoke\Models;
 
 class AwsConfig
 {
-    public function __construct(public int $sqsPollTimeInSeconds = 5) {}
+    public function __construct(public int $sqsPollTimeInSeconds = 5, public int $dlqMaxRetryCount = 3) {}
 }

--- a/src/Models/AwsConfig.php
+++ b/src/Models/AwsConfig.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace Kekke\Mononoke\Models;
 
-class AwsConfig
+final class AwsConfig
 {
-    public function __construct(public int $sqsPollTimeInSeconds = 5, public int $dlqMaxRetryCount = 3) {}
+    public function __construct(
+        public readonly int $sqsPollTimeInSeconds = 5,
+        public readonly int $dlqMaxRetryCount = 3
+    ) {}
 }

--- a/src/Models/HttpConfig.php
+++ b/src/Models/HttpConfig.php
@@ -8,5 +8,7 @@ final class HttpConfig extends ImmutableConfig
 {
     public function __construct(
         public readonly int $port = 80
-    ) {}
+    ) {
+        parent::__construct();
+    }
 }

--- a/src/Models/HttpConfig.php
+++ b/src/Models/HttpConfig.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Kekke\Mononoke\Models;
 
-class HttpConfig
+final class HttpConfig
 {
-    public function __construct(public int $port = 80) {}
+    public function __construct(
+        public readonly int $port = 80
+    ) {}
 }

--- a/src/Models/HttpConfig.php
+++ b/src/Models/HttpConfig.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Kekke\Mononoke\Models;
 
-final class HttpConfig
+final class HttpConfig extends ImmutableConfig
 {
     public function __construct(
         public readonly int $port = 80

--- a/src/Models/ImmutableConfig.php
+++ b/src/Models/ImmutableConfig.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kekke\Mononoke\Models;
+
+use Kekke\Mononoke\Exceptions\MononokeException;
+
+class ImmutableConfig
+{
+    public function with(string $prop, mixed $value): static
+    {
+        $reflection = new \ReflectionClass(static::class);
+        $constructor = $reflection->getConstructor();
+        $args = [];
+
+        if (is_null($constructor)) {
+            throw new MononokeException("Invalid constructor in subclass of ImmutableConfig");
+        }
+
+        foreach ($constructor->getParameters() as $param) {
+            $name = $param->getName();
+            $args[] = ($name === $prop) ? $value : $this->{$name};
+        }
+
+        /** @var static */
+        return $reflection->newInstanceArgs($args);
+    }
+}

--- a/src/Models/ImmutableConfig.php
+++ b/src/Models/ImmutableConfig.php
@@ -4,23 +4,49 @@ declare(strict_types=1);
 
 namespace Kekke\Mononoke\Models;
 
+use Kekke\Mononoke\Exceptions\ImmutableConfigIsNotImmutableException;
 use Kekke\Mononoke\Exceptions\MononokeException;
 
 class ImmutableConfig
 {
+    public function __construct()
+    {
+        $reflection = new \ReflectionClass(static::class);
+
+        foreach ($reflection->getProperties() as $prop) {
+            if (!$prop->isPromoted() || !$prop->isReadOnly()) {
+                throw new ImmutableConfigIsNotImmutableException(sprintf(
+                    'Property $%s in %s must be promoted and readonly in constructor',
+                    $prop->getName(),
+                    static::class
+                ));
+            }
+        }
+    }
+
     public function with(string $prop, mixed $value): static
     {
         $reflection = new \ReflectionClass(static::class);
         $constructor = $reflection->getConstructor();
         $args = [];
-
+        
         if (is_null($constructor)) {
-            throw new MononokeException("Invalid constructor in subclass of ImmutableConfig");
+            throw new MononokeException(sprintf("Invalid constructor in subclass %s of ImmutableConfig", static::class));
         }
-
+        
+        $found = false;
         foreach ($constructor->getParameters() as $param) {
             $name = $param->getName();
-            $args[] = ($name === $prop) ? $value : $this->{$name};
+            if ($name === $prop) {
+                $args[] = $value;
+                $found = true;
+            } else {
+                $args[] = $this->{$name};
+            }
+        }
+
+        if (!$found) {
+            throw new MononokeException(sprintf("Property '%s' does not exist in %s", $prop, static::class));
         }
 
         /** @var static */

--- a/src/Models/MononokeConfig.php
+++ b/src/Models/MononokeConfig.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Kekke\Mononoke\Models;
 
-final class MononokeConfig
+final class MononokeConfig extends ImmutableConfig
 {
     public function __construct(
         public readonly string $serviceName = 'default',

--- a/src/Models/MononokeConfig.php
+++ b/src/Models/MononokeConfig.php
@@ -9,5 +9,7 @@ final class MononokeConfig extends ImmutableConfig
     public function __construct(
         public readonly string $serviceName = 'default',
         public readonly int $numberOfTaskWorkers = 2
-    ) {}
+    ) {
+        parent::__construct();
+    }
 }

--- a/src/Models/MononokeConfig.php
+++ b/src/Models/MononokeConfig.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace Kekke\Mononoke\Models;
 
-class MononokeConfig
+final class MononokeConfig
 {
-    public function __construct(public string $serviceName = 'default', public int $numberOfTaskWorkers = 2) {}
+    public function __construct(
+        public readonly string $serviceName = 'default',
+        public readonly int $numberOfTaskWorkers = 2
+    ) {}
 }

--- a/src/Service.php
+++ b/src/Service.php
@@ -132,7 +132,7 @@ class Service
             foreach ($entry['attributes'] as $attr) {
                 // Setup sns and sqs
                 $installer = new SnsSqsInstaller($attr->topicName, $attr->queueName, $attr->dlqName);
-                $installer->setup();
+                $installer->setup(config: $this->config->aws);
                 $queueUrl = $installer->getQueueUrl();
 
                 // Setup poller

--- a/src/Service.php
+++ b/src/Service.php
@@ -32,6 +32,7 @@ use Swoole\Constant;
 use Swoole\Event;
 use Swoole\Server;
 use Swoole\Timer;
+use Throwable;
 
 /**
  * Main entrypoint for a Mononoke service
@@ -130,7 +131,7 @@ class Service
         foreach ($queueMethods as $entry) {
             foreach ($entry['attributes'] as $attr) {
                 // Setup sns and sqs
-                $installer = new SnsSqsInstaller($attr->topicName, $attr->queueName);
+                $installer = new SnsSqsInstaller($attr->topicName, $attr->queueName, $attr->dlqName);
                 $installer->setup();
                 $queueUrl = $installer->getQueueUrl();
 
@@ -156,8 +157,12 @@ class Service
                     $messages = $queueEntry['poller']->poll();
 
                     foreach ($messages as $message) {
-                        $queueEntry['handler']->handle($message['Body']);
-                        $queueEntry['poller']->delete($message['ReceiptHandle']);
+                        try {
+                            $queueEntry['handler']->handle($message['Body']);
+                            $queueEntry['poller']->delete($message['ReceiptHandle']);
+                        } catch (Throwable $e) {
+                            Logger::exception("Error occured when handling message", $e);
+                        }
                     }
                 }
             });

--- a/tests/Aws/SnsSqsInstallerTest.php
+++ b/tests/Aws/SnsSqsInstallerTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kekke\Mononoke\Tests\Aws;
+
+use Aws\Result;
+use Kekke\Mononoke\Aws\SnsSqsInstaller;
+use Kekke\Mononoke\Exceptions\MononokeException;
+use Kekke\Mononoke\Services\SnsService;
+use Kekke\Mononoke\Services\SqsService;
+use PHPUnit\Framework\TestCase;
+
+class SnsSqsInstallerTest extends TestCase
+{
+    public function testSetupCreatesTopicAndQueueWithoutDlq(): void
+    {
+        // Arrange
+        $snsMock = $this->createMock(SnsService::class);
+        $sqsMock = $this->createMock(SqsService::class);
+
+        $snsMock->expects($this->once())
+            ->method('create')
+            ->with($this->equalTo('test-topic'))
+            ->willReturn('arn:aws:sns:us-east-1:123456789012:test-topic');
+
+        $sqsMock->expects($this->once())
+            ->method('create')
+            ->with('test-queue')
+            ->willReturn('https://sqs.us-east-1.amazonaws.com/123456789012/test-queue');
+
+        $sqsMock->expects($this->once())
+            ->method('getAttributes')
+            ->with(
+                'https://sqs.us-east-1.amazonaws.com/123456789012/test-queue',
+                ['QueueArn']
+            )
+            ->willReturn(new Result([
+                'Attributes' => [
+                    'QueueArn' => 'arn:aws:sqs:us-east-1:123456789012:test-queue'
+                ]
+            ]));
+
+        $sqsMock->expects($this->once())
+            ->method('allowSnsToSendMessagesToQueue')
+            ->with(
+                $this->anything(),
+                'arn:aws:sqs:us-east-1:123456789012:test-queue',
+                'arn:aws:sns:us-east-1:123456789012:test-topic'
+            );
+
+        $snsMock->expects($this->once())
+            ->method('subscribe')
+            ->with(
+                'arn:aws:sns:us-east-1:123456789012:test-topic',
+                'arn:aws:sqs:us-east-1:123456789012:test-queue'
+            );
+
+        // Act
+        $installer = new SnsSqsInstaller('test-topic', 'test-queue', null);
+        $installer->setup($snsMock, $sqsMock);
+
+        // Assert
+        $this->assertSame(
+            'https://sqs.us-east-1.amazonaws.com/123456789012/test-queue',
+            $installer->getQueueUrl()
+        );
+    }
+
+    public function testSetupCreatesTopicAndQueueWithDlq(): void
+    {
+        // Arrange
+        $snsMock = $this->createMock(SnsService::class);
+        $sqsMock = $this->createMock(SqsService::class);
+
+        $snsMock->method('create')
+            ->willReturn('arn:aws:sns:us-east-1:123456789012:test-topic');
+
+        $sqsMock->method('create')
+            ->willReturnCallback(function (string $queueName) {
+                if ($queueName === 'test-dlq') {
+                    return 'https://sqs.us-east-1.amazonaws.com/123456789012/test-dlq';
+                }
+                if ($queueName === 'test-queue') {
+                    return 'https://sqs.us-east-1.amazonaws.com/123456789012/test-queue';
+                }
+                $this->fail("Unexpected queueName: {$queueName}");
+            });
+
+        $sqsMock->method('getAttributes')
+            ->willReturnCallback(function (string $queueUrl, array $attrs) {
+                if ($queueUrl === 'https://sqs.us-east-1.amazonaws.com/123456789012/test-queue') {
+                    return new Result([
+                        'Attributes' => [
+                            'QueueArn' => 'arn:aws:sqs:us-east-1:123456789012:test-queue'
+                        ]
+                    ]);
+                }
+                if ($queueUrl === 'https://sqs.us-east-1.amazonaws.com/123456789012/test-dlq') {
+                    return new Result([
+                        'Attributes' => [
+                            'QueueArn' => 'arn:aws:sqs:us-east-1:123456789012:test-dlq'
+                        ]
+                    ]);
+                }
+                $this->fail("Unexpected queueUrl: {$queueUrl}");
+            });
+
+        $sqsMock->expects($this->once())
+            ->method('setAttributes')
+            ->with(
+                'https://sqs.us-east-1.amazonaws.com/123456789012/test-queue',
+                $this->callback(function ($attributes) {
+                    $policy = json_decode($attributes['RedrivePolicy'], true);
+                    return $policy['deadLetterTargetArn'] === 'arn:aws:sqs:us-east-1:123456789012:test-dlq'
+                        && $policy['maxReceiveCount'] === 5;
+                })
+            );
+
+        // Act
+        $installer = new SnsSqsInstaller('test-topic', 'test-queue', 'test-dlq');
+        $installer->setup($snsMock, $sqsMock);
+    }
+
+    public function testThrowsIfQueueArnMissing(): void
+    {
+        // Arrange
+        $this->expectException(MononokeException::class);
+        $this->expectExceptionMessage('Missing Queue Attributes for queue');
+
+        $snsMock = $this->createMock(SnsService::class);
+        $sqsMock = $this->createMock(SqsService::class);
+
+        $snsMock->method('create')->willReturn('arn:aws:sns:us-east-1:123456789012:test-topic');
+        $sqsMock->method('create')->willReturn('https://sqs.us-east-1.amazonaws.com/123456789012/test-queue');
+        $sqsMock->method('getAttributes')->willReturn(new Result(['Attributes' => []]));
+
+        // Act
+        $installer = new SnsSqsInstaller('test-topic', 'test-queue', null);
+        $installer->setup($snsMock, $sqsMock);
+    }
+}

--- a/tests/Aws/SnsSqsInstallerTest.php
+++ b/tests/Aws/SnsSqsInstallerTest.php
@@ -7,6 +7,7 @@ namespace Kekke\Mononoke\Tests\Aws;
 use Aws\Result;
 use Kekke\Mononoke\Aws\SnsSqsInstaller;
 use Kekke\Mononoke\Exceptions\MononokeException;
+use Kekke\Mononoke\Models\AwsConfig;
 use Kekke\Mononoke\Services\SnsService;
 use Kekke\Mononoke\Services\SqsService;
 use PHPUnit\Framework\TestCase;
@@ -58,7 +59,7 @@ class SnsSqsInstallerTest extends TestCase
 
         // Act
         $installer = new SnsSqsInstaller('test-topic', 'test-queue', null);
-        $installer->setup($snsMock, $sqsMock);
+        $installer->setup(new AwsConfig(), $snsMock, $sqsMock);
 
         // Assert
         $this->assertSame(
@@ -119,7 +120,7 @@ class SnsSqsInstallerTest extends TestCase
 
         // Act
         $installer = new SnsSqsInstaller('test-topic', 'test-queue', 'test-dlq');
-        $installer->setup($snsMock, $sqsMock);
+        $installer->setup(new AwsConfig(), $snsMock, $sqsMock);
     }
 
     public function testThrowsIfQueueArnMissing(): void
@@ -137,6 +138,6 @@ class SnsSqsInstallerTest extends TestCase
 
         // Act
         $installer = new SnsSqsInstaller('test-topic', 'test-queue', null);
-        $installer->setup($snsMock, $sqsMock);
+        $installer->setup(new AwsConfig(), $snsMock, $sqsMock);
     }
 }

--- a/tests/Aws/SnsSqsInstallerTest.php
+++ b/tests/Aws/SnsSqsInstallerTest.php
@@ -71,6 +71,7 @@ class SnsSqsInstallerTest extends TestCase
     public function testSetupCreatesTopicAndQueueWithDlq(): void
     {
         // Arrange
+        $defaultConfig = new AwsConfig();
         $snsMock = $this->createMock(SnsService::class);
         $sqsMock = $this->createMock(SqsService::class);
 
@@ -111,10 +112,10 @@ class SnsSqsInstallerTest extends TestCase
             ->method('setAttributes')
             ->with(
                 'https://sqs.us-east-1.amazonaws.com/123456789012/test-queue',
-                $this->callback(function ($attributes) {
+                $this->callback(function ($attributes) use ($defaultConfig) {
                     $policy = json_decode($attributes['RedrivePolicy'], true);
                     return $policy['deadLetterTargetArn'] === 'arn:aws:sqs:us-east-1:123456789012:test-dlq'
-                        && $policy['maxReceiveCount'] === 5;
+                        && $policy['maxReceiveCount'] === $defaultConfig->dlqMaxRetryCount;
                 })
             );
 

--- a/tests/Config/ConfigTest.php
+++ b/tests/Config/ConfigTest.php
@@ -36,6 +36,16 @@ final class ConfigTest extends TestCase
         $this->assertSame(8080, $config->http->port);
     }
 
+    public function testDlqOverrideFromEnv(): void
+    {
+        putenv('SQS_DLQ_MAX_RETRIES=5');
+        $service = new TestService();
+        $service->loadConfig();
+        $config = $service->getConfig();
+
+        $this->assertSame(5, $config->aws->dlqMaxRetryCount);
+    }
+
     public function testHttpPortOverrideFromEnv(): void
     {
         putenv('HTTP_PORT=9090');

--- a/tests/Config/ImmutableConfigTest.php
+++ b/tests/Config/ImmutableConfigTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+use Kekke\Mononoke\Exceptions\ImmutableConfigIsNotImmutableException;
+use Kekke\Mononoke\Exceptions\MononokeException;
+use Kekke\Mononoke\Models\ImmutableConfig;
+use PHPUnit\Framework\TestCase;
+
+final class InvalidConfig extends ImmutableConfig
+{
+    public function __construct(public int $notImmutable = 5)
+    {
+        parent::__construct();
+    }
+}
+
+final class ValidConfig extends ImmutableConfig
+{
+    public function __construct(
+        public readonly int $foo = 1,
+        public readonly string $bar = 'baz'
+    ) {
+        parent::__construct();
+    }
+}
+
+final class ImmutableConfigTest extends TestCase
+{
+    public function testInvalidConfigThrowsException(): void
+    {
+        $this->expectException(ImmutableConfigIsNotImmutableException::class);
+        $this->expectExceptionMessage('Property $notImmutable in InvalidConfig must be promoted and readonly in constructor');
+
+        $config = new InvalidConfig();
+    }
+
+    public function testWithOverridesValue(): void
+    {
+        $config = new ValidConfig(foo: 5, bar: 'baz');
+        $newConfig = $config->with('foo', 10);
+
+        $this->assertInstanceOf(ValidConfig::class, $newConfig);
+        $this->assertSame(10, $newConfig->foo);
+        $this->assertSame('baz', $newConfig->bar);
+        $this->assertNotSame($config, $newConfig);
+    }
+
+    public function testWithInvalidPropertyThrows(): void
+    {
+        $this->expectException(MononokeException::class);
+        $this->expectExceptionMessage("Property 'nonExistent' does not exist in ValidConfig");
+        
+        $config = new ValidConfig();
+        $config->with('nonExistent', 123);
+    }
+
+    public function testValidConfigDoesNotThrow(): void
+    {
+        $config = new ValidConfig();
+        $this->assertInstanceOf(ValidConfig::class, $config);
+    }
+}


### PR DESCRIPTION
This PR adds the ability to use a Dead Letter Queue with AWS SQS.

In order to use a DLQ, specify the `dlqName` param of the `AwsSnsSqs` attribute;
```php
    #[AwsSnsSqs(topicName: 'sns-topic', queueName: 'sqs-queue', dlqName: 'sqs-queue-dlq')]
    public function queueWithDlq($message)
    {
        throw new Exception("Error occurred, send to dlq after 3 tries");
    }
```

What happens behind the scenes is that if the `dlqName` is specified and valid (alphanumeric with dashes and hyphens), the service will create another sqs queue with the name of `dlqName` and then add a `RedrivePolicy` targeting the DLQ to the previously created SQS queue.