### PR TITLE
feat: Add runtime hooks

### DIFF
--- a/examples/hooks.php
+++ b/examples/hooks.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use Kekke\Mononoke\Attributes\Config;
+use Kekke\Mononoke\Attributes\Hook;
+use Kekke\Mononoke\Attributes\Http;
+use Kekke\Mononoke\Attributes\Schedule;
+use Kekke\Mononoke\Enums\HttpMethod;
+use Kekke\Mononoke\Enums\RuntimeEvent;
+use Kekke\Mononoke\Enums\Scheduler;
+use Kekke\Mononoke\Helpers\Logger;
+use Kekke\Mononoke\Models\AwsConfig;
+use Kekke\Mononoke\Models\HttpConfig;
+use Kekke\Mononoke\Models\MononokeConfig;
+use Kekke\Mononoke\Service as MononokeService;
+
+
+#[Config(
+    mononoke: new MononokeConfig(numberOfTaskWorkers: 5),
+    aws: new AwsConfig(sqsPollTimeInSeconds: 10),
+    http: new HttpConfig(port: 8080),
+)]
+class Service extends MononokeService
+{
+    #[Hook(event: RuntimeEvent::OnStart)]
+    public function onStart()
+    {
+        Logger::info("Service started");
+    }
+
+    #[Hook(event: RuntimeEvent::OnShutdown)]
+    public function onShutdown()
+    {
+        Logger::info("Service shutdown");
+    }
+
+    #[Schedule(Scheduler::EverySecond, invokeImmediately: true)]
+    public function schedule(): void
+    {
+        Logger::info("--- Scheduler");
+    }
+}

--- a/src/Attributes/Hook.php
+++ b/src/Attributes/Hook.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kekke\Mononoke\Attributes;
+
+use Attribute;
+use Kekke\Mononoke\Enums\RuntimeEvent;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+class Hook
+{
+    public function __construct(public RuntimeEvent $event) {}
+}

--- a/src/Attributes/Hook.php
+++ b/src/Attributes/Hook.php
@@ -7,6 +7,9 @@ namespace Kekke\Mononoke\Attributes;
 use Attribute;
 use Kekke\Mononoke\Enums\RuntimeEvent;
 
+/**
+ * Attribute to define a hook.
+ */
 #[Attribute(Attribute::TARGET_METHOD)]
 class Hook
 {

--- a/src/Enums/RuntimeEvent.php
+++ b/src/Enums/RuntimeEvent.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kekke\Mononoke\Enums;
+
+/**
+ * Enum with runtime events
+ */
+enum RuntimeEvent: string
+{
+    case OnStart = 'onStart';
+    case OnShutdown = 'onShutdown';
+}

--- a/src/Framework.php
+++ b/src/Framework.php
@@ -17,7 +17,7 @@ const MAGENTA = "\e[35m";
 
 class Framework
 {
-    private static string $version = "0.1.2";
+    private static string $version = "0.1.4";
 
     public static function run(string $file): void
     {

--- a/src/Helpers/HookDispatcher.php
+++ b/src/Helpers/HookDispatcher.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kekke\Mononoke\Helpers;
+
+use Kekke\Mononoke\Attributes\Hook;
+use Kekke\Mononoke\Enums\RuntimeEvent;
+use ReflectionClass;
+
+class HookDispatcher
+{
+    /** @var array<string, list<callable>> */
+    private array $hooks = [];
+
+    public function __construct(object $service)
+    {
+        $this->register($service);
+    }
+
+    public function register(object $service): void
+    {
+        $reflection = new ReflectionClass($service);
+        foreach ($reflection->getMethods() as $method) {
+            foreach ($method->getAttributes(Hook::class) as $attr) {
+                $hook = $attr->newInstance();
+                /** @var callable(): mixed $callable */
+                $callable = [$service, $method->getName()];
+                $this->hooks[$hook->event->value][] = $callable;
+            }
+        }
+    }
+
+    public function trigger(RuntimeEvent $event): void
+    {
+        foreach ($this->hooks[$event->value] ?? [] as $callable) {
+            ($callable)();
+        }
+    }
+}

--- a/src/Service.php
+++ b/src/Service.php
@@ -78,7 +78,7 @@ class Service
             $this->server = &$server;
             $server->start();
         } else {
-            $this->setupSignalHandlers($hookDispatcher, $server);
+            $this->setupSignalHandlers($hookDispatcher);
             Event::wait();
         }
     }
@@ -96,26 +96,18 @@ class Service
         return $this->config;
     }
 
-    private function setupSignalHandlers(HookDispatcher $hookDispatcher, ?Server $server = null): void
+    private function setupSignalHandlers(HookDispatcher $hookDispatcher): void
     {
-        Process::signal(SIGINT, function () use ($server, $hookDispatcher) {
+        Process::signal(SIGINT, function () use ($hookDispatcher) {
             $hookDispatcher->trigger(RuntimeEvent::OnShutdown);
 
-            if (!is_null($server)) {
-                $server->shutdown();
-            } else {
-                Event::exit();
-            }
+            Event::exit();
         });
 
-        Process::signal(SIGTERM, function () use ($server, $hookDispatcher) {
+        Process::signal(SIGTERM, function () use ($hookDispatcher) {
             $hookDispatcher->trigger(RuntimeEvent::OnShutdown);
 
-            if (!is_null($server)) {
-                $server->shutdown();
-            } else {
-                Event::exit();
-            }
+            Event::exit();
         });
     }
 

--- a/src/Service.php
+++ b/src/Service.php
@@ -15,6 +15,8 @@ use Kekke\Mononoke\Aws\SqsMessageHandler;
 use Kekke\Mononoke\Aws\SqsPoller;
 use Kekke\Mononoke\Config\ConfigLoader;
 use Kekke\Mononoke\Enums\ClientType;
+use Kekke\Mononoke\Enums\RuntimeEvent;
+use Kekke\Mononoke\Helpers\HookDispatcher;
 use Kekke\Mononoke\Helpers\Logger;
 use Kekke\Mononoke\Reflection\AttributeScanner;
 use Kekke\Mononoke\Scheduling\ScheduledInvoker;
@@ -30,6 +32,7 @@ use Kekke\Mononoke\Server\Task\TaskRouteLoader;
 use Kekke\Mononoke\Server\WebSocket\WebSocketServerFactory;
 use Swoole\Constant;
 use Swoole\Event;
+use Swoole\Process;
 use Swoole\Server;
 use Swoole\Timer;
 use Throwable;
@@ -51,6 +54,7 @@ class Service
      */
     final public function run(): void
     {
+        $hookDispatcher = new HookDispatcher($this);
         $httpRouteLoader = new HttpRouteLoader();
         $wsRouteLoader = new WebSocketRouteLoader();
         $taskRouteLoader = new TaskRouteLoader();
@@ -61,17 +65,20 @@ class Service
 
         $options = new Options($httpRoutes, $wsRoutes, $taskRoutes, $this->config);
 
-        $server = $this->setupServer($options);
+        $server = $this->setupServer($options, $hookDispatcher);
 
         $this->setupQueuePoller();
         $this->setupScheduler();
-
+        
         Logger::info("Mononoke framework up and running!");
-
+        
+        $hookDispatcher->trigger(RuntimeEvent::OnStart);
+        
         if (!is_null($server)) {
             $this->server = &$server;
             $server->start();
         } else {
+            $this->setupSignalHandlers($hookDispatcher, $server);
             Event::wait();
         }
     }
@@ -89,7 +96,30 @@ class Service
         return $this->config;
     }
 
-    private function setupServer(Options $options): ?Server
+    private function setupSignalHandlers(HookDispatcher $hookDispatcher, ?Server $server = null): void
+    {
+        Process::signal(SIGINT, function () use ($server, $hookDispatcher) {
+            $hookDispatcher->trigger(RuntimeEvent::OnShutdown);
+
+            if (!is_null($server)) {
+                $server->shutdown();
+            } else {
+                Event::exit();
+            }
+        });
+
+        Process::signal(SIGTERM, function () use ($server, $hookDispatcher) {
+            $hookDispatcher->trigger(RuntimeEvent::OnShutdown);
+
+            if (!is_null($server)) {
+                $server->shutdown();
+            } else {
+                Event::exit();
+            }
+        });
+    }
+
+    private function setupServer(Options $options, HookDispatcher $hookDispatcher): ?Server
     {
         $server = null;
 
@@ -117,6 +147,12 @@ class Service
 
             $server->set([Constant::OPTION_TASK_WORKER_NUM => $this->config->mononoke->numberOfTaskWorkers]); // @phpstan-ignore-line
             Logger::info("Created {$this->config->mononoke->numberOfTaskWorkers} task workers");
+        }
+
+        if (!is_null($server)) {
+            $server->on('Shutdown', function () use ($hookDispatcher) {
+                $hookDispatcher->trigger(RuntimeEvent::OnShutdown);
+            });
         }
 
         return $server;


### PR DESCRIPTION
This PR adds runtime hooks to Monononoke.

Right now I've added 2 events: `OnStart` and `OnShutdown` which will be triggered by the new `HookDispatcher`.

Usage:

```php
    #[Hook(event: RuntimeEvent::OnStart)]
    public function onStart()
    {
        Logger::info("Service started");
    }

    #[Hook(event: RuntimeEvent::OnShutdown)]
    public function onShutdown()
    {
        Logger::info("Service shutdown");
    }
```

**_Note:
The `OnShutdown` is not working properly when sending an SIGINT and using a \Swoole\Server._**