### PR TITLE
fix: request obj missing from http handlers

### DIFF
--- a/examples/http.php
+++ b/examples/http.php
@@ -11,11 +11,9 @@ use Kekke\Mononoke\Models\AwsConfig;
 use Kekke\Mononoke\Models\HttpConfig;
 use Kekke\Mononoke\Models\MononokeConfig;
 use Kekke\Mononoke\Service as MononokeService;
-
+use Swoole\Http\Request;
 
 #[Config(
-    mononoke: new MononokeConfig(numberOfTaskWorkers: 5),
-    aws: new AwsConfig(sqsPollTimeInSeconds: 10),
     http: new HttpConfig(port: 8080),
 )]
 class Service extends MononokeService
@@ -35,6 +33,14 @@ class Service extends MononokeService
     #[Http('GET', '/custom')]
     public function custom()
     {
+        return new Psr7Response(201, ['Authorization' => 'Bearer XXX'], "Body");
+    }
+
+    #[Http('POST', '/post')]
+    public function post(Request $request)
+    {
+        var_dump($request->header);
+        var_dump($request->getContent());
         return new Psr7Response(201, ['Authorization' => 'Bearer XXX'], "Body");
     }
 }

--- a/src/Server/Http/HttpServerFactory.php
+++ b/src/Server/Http/HttpServerFactory.php
@@ -59,7 +59,7 @@ class HttpServerFactory implements ServerFactory
                     case \FastRoute\Dispatcher::FOUND:
                         $handler = $routeInfo[1];
                         $vars    = $routeInfo[2];
-                        $this->handleRoute($handler, $vars, $response);
+                        $this->handleRoute($handler, $request, $vars, $response);
                         break;
 
                     default:

--- a/src/Server/Http/Traits/RouteHandler.php
+++ b/src/Server/Http/Traits/RouteHandler.php
@@ -6,6 +6,7 @@ namespace Kekke\Mononoke\Server\Http\Traits;
 
 use GuzzleHttp\Psr7\Response as Psr7Response;
 use Kekke\Mononoke\Helpers\Logger;
+use Swoole\Http\Request;
 use Swoole\Http\Response;
 
 trait RouteHandler
@@ -13,9 +14,9 @@ trait RouteHandler
     /**
      * @param array<string, string> $vars
      */
-    public function handleRoute(callable $handler, array $vars, Response $response): void
+    public function handleRoute(callable $handler, Request $request, array $vars, Response $response): void
     {
-        $result = call_user_func_array($handler, $vars);
+        $result = call_user_func_array($handler, [$request, ...$vars]);
 
         switch (true) {
             case $result instanceof Psr7Response:


### PR DESCRIPTION
Add \Swoole\Request to all http handlers as the first parameter.

Usage:

```php
    #[Http('POST', '/post')]
    public function post(Request $request)
    {
        var_dump($request->header);
        var_dump($request->getContent());
        return new Psr7Response(201, ['Authorization' => 'Bearer XXX'], "Body");
    }
```