### PR TITLE
Feat: Add option to not create aws resources 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       - AWS_ACCESS_KEY_ID=test
       - AWS_SECRET_ACCESS_KEY=test
       - AWS_ENDPOINT_URL=http://localstack:4566
+      - AWS_ACCOUNT_ID=012345678901
       - XDEBUG_MODE=debug
       - XDEBUG_CLIENT_HOST=host.docker.internal
       - SERVICE_FILE=sns.php

--- a/src/Aws/SnsSqsInstaller.php
+++ b/src/Aws/SnsSqsInstaller.php
@@ -15,13 +15,70 @@ class SnsSqsInstaller
     private string $queueUrl;
     private ?string $dlqUrl = null;
 
-    public function __construct(private string $topicName, private string $queueName, private ?string $dlqName) {}
+    public function __construct(private string $topicName, private string $queueName, private ?string $dlqName, private bool $autoCreate = true) {}
+
+    /**
+     * Method to get the AWS_REGION
+     * This is only used when not automatically creating resources in AWS.
+     */
+    private function getAwsRegion(): string
+    {
+        return getenv('AWS_REGION')
+            ?: getenv('AWS_DEFAULT_REGION')
+            ?: throw new MononokeException("AWS region not set in environment");
+    }
+
+    /**
+     * Method to get the AWS_ACCOUNT_ID env variable
+     * This is only used when not automatically creating resources in AWS.
+     */
+    private function getAwsAccountId(): string
+    {
+        $id = getenv('AWS_ACCOUNT_ID');
+
+        if (!$id) {
+            throw new MononokeException("AWS_ACCOUNT_ID must be set in environment when using autoCreate false");
+        }
+
+        return $id;
+    }
 
     /**
      * Sets up a SNS topic and a SQS queue
      */
     public function setup(AwsConfig $config = new AwsConfig(), SnsService $snsService = new SnsService(), SqsService $sqsService = new SqsService()): void
     {
+        /**
+         * If we are not creating sns topic, sqs queue and subscribing queue to topic, then just build the queueUrl 
+         * so that we can poll from it.
+         */
+        if (!$this->autoCreate) {
+            $region    = $this->getAwsRegion();
+            $accountId = $this->getAwsAccountId();
+
+            if (!is_null($this->dlqName)) {
+                $this->dlqUrl = sprintf(
+                    'https://sqs.%s.amazonaws.com/%s/%s',
+                    $region,
+                    $accountId,
+                    $this->dlqName
+                );
+            }
+
+            $this->queueUrl = sprintf(
+                'https://sqs.%s.amazonaws.com/%s/%s',
+                $region,
+                $accountId,
+                $this->queueName
+            );
+
+            return;
+        }
+
+        /**
+         * This is creating a SNS topic, a SQS queue, optionally a DLQ queue, and then subscribing 
+         * the SQS queue to the SNS topic
+         */
         try {
             $topicArn = $snsService->create(topicName: $this->topicName);
         } catch (MononokeException $e) {

--- a/src/Aws/SnsSqsInstaller.php
+++ b/src/Aws/SnsSqsInstaller.php
@@ -15,7 +15,7 @@ class SnsSqsInstaller
     private string $queueUrl;
     private ?string $dlqUrl = null;
 
-    public function __construct(private string $topicName, private string $queueName, private ?string $dlqName, private bool $autoCreate = true) {}
+    public function __construct(private string $topicName, private string $queueName, private ?string $dlqName) {}
 
     /**
      * Method to get the AWS_REGION
@@ -52,7 +52,7 @@ class SnsSqsInstaller
          * If we are not creating sns topic, sqs queue and subscribing queue to topic, then just build the queueUrl 
          * so that we can poll from it.
          */
-        if (!$this->autoCreate) {
+        if (!$config->autoCreateResources) {
             $region    = $this->getAwsRegion();
             $accountId = $this->getAwsAccountId();
 

--- a/src/Models/AwsConfig.php
+++ b/src/Models/AwsConfig.php
@@ -8,7 +8,8 @@ final class AwsConfig extends ImmutableConfig
 {
     public function __construct(
         public readonly int $sqsPollTimeInSeconds = 5,
-        public readonly int $dlqMaxRetryCount = 3
+        public readonly int $dlqMaxRetryCount = 3,
+        public readonly bool $autoCreateResources = true
     ) {
         parent::__construct();
     }

--- a/tests/Aws/SnsSqsInstallerTest.php
+++ b/tests/Aws/SnsSqsInstallerTest.php
@@ -68,6 +68,37 @@ class SnsSqsInstallerTest extends TestCase
         );
     }
 
+    public function testSetupDoesNotCreateTopicOrQueueWhenAutoCreateIsFalse(): void
+    {
+        // Arrange
+        putenv('AWS_REGION=us-east-1');
+        putenv('AWS_ACCOUNT_ID=123456789012');
+
+        $snsMock = $this->createMock(SnsService::class);
+        $sqsMock = $this->createMock(SqsService::class);
+
+        $snsMock->expects($this->never())
+            ->method('create');
+
+        $sqsMock->expects($this->never())
+            ->method('create');
+
+        $queueUrl = 'https://sqs.us-east-1.amazonaws.com/123456789012/test-queue';
+
+        // Act
+        $installer = new SnsSqsInstaller(
+            topicName: 'test-topic',
+            queueName: 'test-queue',
+            dlqName: null,
+            autoCreate: false
+        );
+
+        $installer->setup(new AwsConfig(), $snsMock, $sqsMock);
+
+        // Assert
+        $this->assertSame($queueUrl, $installer->getQueueUrl());
+    }
+
     public function testSetupCreatesTopicAndQueueWithDlq(): void
     {
         // Arrange

--- a/tests/Aws/SnsSqsInstallerTest.php
+++ b/tests/Aws/SnsSqsInstallerTest.php
@@ -14,6 +14,14 @@ use PHPUnit\Framework\TestCase;
 
 class SnsSqsInstallerTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        putenv('AWS_REGION');
+        putenv('AWS_ACCOUNT_ID');
+
+        parent::tearDown();
+    }
+
     public function testSetupCreatesTopicAndQueueWithoutDlq(): void
     {
         // Arrange

--- a/tests/Aws/SnsSqsInstallerTest.php
+++ b/tests/Aws/SnsSqsInstallerTest.php
@@ -90,10 +90,9 @@ class SnsSqsInstallerTest extends TestCase
             topicName: 'test-topic',
             queueName: 'test-queue',
             dlqName: null,
-            autoCreate: false
         );
 
-        $installer->setup(new AwsConfig(), $snsMock, $sqsMock);
+        $installer->setup(new AwsConfig(autoCreateResources: false), $snsMock, $sqsMock);
 
         // Assert
         $this->assertSame($queueUrl, $installer->getQueueUrl());


### PR DESCRIPTION
# Add Support for not creating SNS/SQS/DLQ resources in AWS (autoCreate=false)

This PR introduces the ability to use existing SNS topics and SQS queues without requiring AWS permissions for CreateTopic or CreateQueue.
This enables Mononoke services to run in restricted AWS environments where infrastructure is provisioned externally.

## Key Changes
1. SNS topic resolution no longer requires create permissions
When autoCreate=false, the installer now:
Reads AWS account ID and region from AWS_REGION and AWS_ACCOUNT_ID.
Does not call CreateTopic.

2. SQS queue resolution without creation
When autoCreate=false, the installer now:
Resolves the queue URL using GetQueueUrl.
Does not call CreateQueue.

3. Updated unit tests
Added testSetupDoesNotCreateTopicOrQueueWhenAutoCreateIsFalse.
Ensures:
No create() calls occur on SNS or SQS services.
Queue URL is resolved and set correctly.
Environment variables (AWS_REGION, AWS_ACCOUNT_ID) are respected.