### PR TITLE
Docker compose up has a faulty command

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       - SERVICE_FILE=sns.php
     volumes:
       - ./src/:/app/src/
-    command: ["/app/src/bin/mononoke /app/examples/${SERVICE_FILE:-sns.php}"]
+    command: ["/app/examples/${SERVICE_FILE:-sns.php}"]
 
 volumes:
   localstack_data:


### PR DESCRIPTION
This PR fixes a faulty command inside the docker-compose.yml

It currently expects a file to be run but we are passing in:
```
    command: ["/app/src/bin/mononoke /app/examples/${SERVICE_FILE:-sns.php}"]
```